### PR TITLE
feat(recipient): add recipient model

### DIFF
--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -7,6 +7,7 @@ class Owner < ApplicationRecord
   has_many :contact_infos, dependent: :destroy
   has_one :document, dependent: :destroy
   has_one :address, dependent: :destroy
+  has_many :recipient, dependent: :destroy
 
   validates_presence_of :legal_name
 end

--- a/app/models/owner.rb_
+++ b/app/models/owner.rb_
@@ -1,7 +1,0 @@
-class Owner < ApplicationRecord
-  has_many :contact_infos, dependent: :destroy
-  has_one :document, dependent: :destroy
-  has_one :address, dependent: :destroy
-
-  validates_presence_of :legal_name
-end

--- a/app/models/recipient.rb
+++ b/app/models/recipient.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This class represents a recipient, it will have any information necessary to send
+# transferences to Owne and is used to map all transactions which belongs to a specific
+# Onwer.
+class Recipient < ApplicationRecord
+  belongs_to :owner
+end

--- a/app/models/recipient.rb
+++ b/app/models/recipient.rb
@@ -5,4 +5,6 @@
 # Onwer.
 class Recipient < ApplicationRecord
   belongs_to :owner
+
+  validates_presence_of :remote_id, :provider_name
 end

--- a/db/migrate/20180910024445_create_recipients.rb
+++ b/db/migrate/20180910024445_create_recipients.rb
@@ -1,0 +1,11 @@
+class CreateRecipients < ActiveRecord::Migration[5.2]
+  def change
+    create_table :recipients do |t|
+      t.string :remote_id
+      t.string :provider_name
+      t.references :owner, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_08_044648) do
+ActiveRecord::Schema.define(version: 2018_09_10_024445) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,7 +51,17 @@ ActiveRecord::Schema.define(version: 2018_09_08_044648) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "recipients", force: :cascade do |t|
+    t.string "remote_id"
+    t.string "provider_name"
+    t.bigint "owner_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["owner_id"], name: "index_recipients_on_owner_id"
+  end
+
   add_foreign_key "addresses", "owners"
   add_foreign_key "contact_infos", "owners"
   add_foreign_key "documents", "owners"
+  add_foreign_key "recipients", "owners"
 end

--- a/spec/factories/recipients.rb
+++ b/spec/factories/recipients.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# frozen_string_litreal: true
+
+FactoryBot.define do
+  factory :recipient do
+    remote_id { Faker::Internet.password(10) }
+    # TODO: (walteraa) randomize it by using existing providers in our system
+    provider_name { Faker::Internet.username }
+    owner { nil }
+  end
+end

--- a/spec/models/owner_spec.rb
+++ b/spec/models/owner_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Owner, type: :model do
   it { should have_many(:contact_infos) }
   it { should have_one(:document) }
   it { should have_one(:address) }
+  it { should have_many(:recipient) }
 
   it { should validate_presence_of(:legal_name) }
 end

--- a/spec/models/recipient_spec.rb
+++ b/spec/models/recipient_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Recipient, type: :model do
+  it { should belong_to(:owner) }
+
+  it { should validate_presence_of(:remote_id) }
+  it { should validate_presence_of(:provider_name) }
+end


### PR DESCRIPTION
Add recipient model in the project.

It should belong to an Owner and will be responsible to save recipient information of Customers in the providers.


The Customer's bank account information should be related to this model.