### PR TITLE
Fix(models): Fix Document and Contact infos type column

### DIFF
--- a/app/models/contact_info.rb
+++ b/app/models/contact_info.rb
@@ -5,5 +5,5 @@
 class ContactInfo < ApplicationRecord
   belongs_to :owner
 
-  validates_presence_of :type, :info
+  validates_presence_of :contact_type, :info
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -5,5 +5,5 @@
 # validations
 class Document < ApplicationRecord
   belongs_to :owner
-  validates_presence_of :type, :number
+  validates_presence_of :document_type, :number
 end

--- a/db/migrate/20180917071000_change_document_type_column.rb
+++ b/db/migrate/20180917071000_change_document_type_column.rb
@@ -1,0 +1,5 @@
+class ChangeDocumentTypeColumn < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :documents, :type, :document_type
+  end
+end

--- a/db/migrate/20180917071204_change_contact_info_type_column.rb
+++ b/db/migrate/20180917071204_change_contact_info_type_column.rb
@@ -1,0 +1,5 @@
+class ChangeContactInfoTypeColumn < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :contact_infos, :type, :contact_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_15_014014) do
+ActiveRecord::Schema.define(version: 2018_09_17_071204) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2018_09_15_014014) do
   end
 
   create_table "contact_infos", force: :cascade do |t|
-    t.string "type"
+    t.string "contact_type"
     t.string "info"
     t.bigint "owner_id"
     t.datetime "created_at", null: false
@@ -49,7 +49,7 @@ ActiveRecord::Schema.define(version: 2018_09_15_014014) do
 
   create_table "documents", force: :cascade do |t|
     t.string "number"
-    t.string "type"
+    t.string "document_type"
     t.bigint "owner_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/contact_infos.rb
+++ b/spec/factories/contact_infos.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :contact_info do
-    type { '' }
+    document_type { '' }
     info { 'MyString' }
     owner { nil }
   end

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :document do
     number { 'MyString' }
-    type { '' }
+    document_type { '' }
   end
 end

--- a/spec/models/contact_info_spec.rb
+++ b/spec/models/contact_info_spec.rb
@@ -5,6 +5,6 @@ require 'rails_helper'
 RSpec.describe ContactInfo, type: :model do
   it { should belong_to(:owner) }
 
-  it { should validate_presence_of(:type) }
+  it { should validate_presence_of(:contact_type) }
   it { should validate_presence_of(:info) }
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -6,5 +6,5 @@ RSpec.describe Document, type: :model do
   it { should belong_to(:owner) }
 
   it { should validate_presence_of(:number) }
-  it { should validate_presence_of(:type) }
+  it { should validate_presence_of(:document_type) }
 end


### PR DESCRIPTION
The column type in Document and Contact Infos was causing erros as
single table inheritance column. The column was changed to document_type
and contact_type respectively