### PR TITLE
Feature/create owner REST API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
     - 'db/**/*'
     - 'spec/rails_helper.rb'
     - 'bin/**'
+    - 'spec/**/*.rb'
 
 # Customize rules
 Metrics/LineLength:

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin
 # AJAX possible
 # gem 'rack-cors'
-
+gem 'active_model_serializers', '~> 0.10.0'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
@@ -43,7 +43,7 @@ group :development, :test do
   gem 'database_cleaner'
   gem 'factory_bot_rails'
   gem 'faker'
-  gem 'rspec-rails', '>= 3.5.0'
+  gem 'rspec-rails', '~> 3.5'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.10.7)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (5.2.1)
       activesupport (= 5.2.1)
       globalid (>= 0.3.6)
@@ -44,10 +49,12 @@ GEM
       tzinfo (~> 1.1)
     arel (9.0.0)
     ast (2.4.0)
-    bootsnap (1.3.1)
+    bootsnap (1.3.2)
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (10.0.2)
+    case_transform (0.2)
+      activesupport
     codeclimate-test-reporter (1.0.8)
       simplecov (<= 0.13)
     concurrent-ruby (1.0.5)
@@ -70,6 +77,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.1)
     json (2.1.0)
+    jsonapi-renderer (0.2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -79,7 +87,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.0)
       mini_mime (>= 0.1.1)
-    marcel (0.3.2)
+    marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.0)
     mimemagic (0.3.2)
@@ -145,7 +153,7 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.59.0)
+    rubocop (0.59.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.5, != 2.5.1.1)
@@ -187,6 +195,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers (~> 0.10.0)
   bootsnap (>= 1.1.0)
   byebug
   codeclimate-test-reporter (~> 1.0.0)
@@ -197,7 +206,7 @@ DEPENDENCIES
   pg
   puma (~> 3.11)
   rails (~> 5.2.1)
-  rspec-rails (>= 3.5.0)
+  rspec-rails (~> 3.5)
   rubocop
   shoulda-matchers
   spring

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::API
+  include Response
+  include ExceptionHandler
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# Inheritance-root for all controllers/APIs. Here we should add all
+# in common includes and methods.
 class ApplicationController < ActionController::API
   include Response
   include ExceptionHandler

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ExceptionHandler
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from ActiveRecord::RecordNotFound do |e|
+      json_response({ message: e.message }, :not_found)
+    end
+
+    rescue_from ActiveRecord::RecordInvalid do |e|
+      json_response({ message: e.message }, :unprocessable_entity)
+    end
+  end
+end

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Handle Record exceptions and transform it in HTTP responses
 module ExceptionHandler
   extend ActiveSupport::Concern
 

--- a/app/controllers/concerns/response.rb
+++ b/app/controllers/concerns/response.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Response
+  def json_response(object, status = :ok)
+    render json: object, status: status
+  end
+end

--- a/app/controllers/concerns/response.rb
+++ b/app/controllers/concerns/response.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# API response mixins
 module Response
   def json_response(object, status = :ok)
     render json: object, status: status

--- a/app/controllers/owners_controller.rb
+++ b/app/controllers/owners_controller.rb
@@ -17,13 +17,18 @@ class OwnersController < ApplicationController
 
   # POST /owners
   def create
-    @owner = Owner.create!(create_owner_params)
-    json_response(@owner, :created)
+    begin
+      @owner = Owner.create!(owner_params)
+      json_response(@owner, :created)
+    rescue ActiveRecord::RecordInvalid, ArgumentError, ActionController::ParameterMissing  => ex
+      head :bad_request
+    end
+
   end
 
   # PUT /owners/:id
   def update
-    @owner = Owner.update!(update_owner_params)
+    @owner = Owner.update!(owner_params)
 
     head :no_content
   end
@@ -39,14 +44,11 @@ class OwnersController < ApplicationController
     @owner = Owner.find(params[:id])
   end
 
-  def create_owner_params
-    params.require(:legal_name, contact_infos_attributes: [], document_attributes: [],
-                                address_attributes: [])
-  end
 
-  def update_owner_params
-    params.permit(:legal_name, contact_infos_attributes: %i[type info],
-                               document_attributes: %i[type number],
-                               address_attributes: %i[street number zip_code])
+  def owner_params
+    params.permit(:legal_name, document_attributes: [:document_type, :number],
+                  contact_infos_attributes: [:contact_type, :info], 
+                  address_attributes: [:street, :number, :zip_code]
+                 )
   end
 end

--- a/app/controllers/owners_controller.rb
+++ b/app/controllers/owners_controller.rb
@@ -28,7 +28,7 @@ class OwnersController < ApplicationController
 
   # PUT /owners/:id
   def update
-    @owner = Owner.update!(owner_params)
+    @owner = Owner.update(owner_params)
 
     head :no_content
   end

--- a/app/controllers/owners_controller.rb
+++ b/app/controllers/owners_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class OwnersController < ApplicationController
+  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  before_action :set_owner, only: %i[show update destroy]
+
+  # GET /owners
+  def index
+    @owners = Owner.all
+    json_response(@owners)
+  end
+
+  # GET /owners/:id
+  def show
+    json_response(@owner)
+  end
+
+  # POST /owners
+  def create
+    @owner = Owner.create!(create_owner_params)
+    json_response(@owner, :created)
+  end
+
+  # PUT /owners/:id
+  def update
+    @owner = Owner.update!(update_owner_params)
+
+    head :no_content
+  end
+
+  def destroy
+    @owner.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_owner
+    @owner = Owner.find(params[:id])
+  end
+
+  def create_owner_params
+    params.require(:legal_name, contact_infos_attributes: [], document_attributes: [],
+                                address_attributes: [])
+  end
+
+  def update_owner_params
+    params.permit(:legal_name, contact_infos_attributes: %i[type info],
+                               document_attributes: %i[type number],
+                               address_attributes: %i[street number zip_code])
+  end
+end

--- a/app/controllers/owners_controller.rb
+++ b/app/controllers/owners_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Owner's REST API. Here are all actions for Owner entity
 class OwnersController < ApplicationController
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   before_action :set_owner, only: %i[show update destroy]
@@ -17,13 +18,10 @@ class OwnersController < ApplicationController
 
   # POST /owners
   def create
-    begin
-      @owner = Owner.create!(owner_params)
-      json_response(@owner, :created)
-    rescue ActiveRecord::RecordInvalid, ArgumentError, ActionController::ParameterMissing  => ex
-      head :bad_request
-    end
-
+    @owner = Owner.create!(owner_params)
+    json_response(@owner, :created)
+  rescue ActiveRecord::RecordInvalid, ArgumentError, ActionController::ParameterMissing
+    head :bad_request
   end
 
   # PUT /owners/:id
@@ -44,11 +42,9 @@ class OwnersController < ApplicationController
     @owner = Owner.find(params[:id])
   end
 
-
   def owner_params
-    params.permit(:legal_name, document_attributes: [:document_type, :number],
-                  contact_infos_attributes: [:contact_type, :info], 
-                  address_attributes: [:street, :number, :zip_code]
-                 )
+    params.permit(:legal_name, document_attributes: %i[document_type number],
+                               contact_infos_attributes: %i[contact_type info],
+                               address_attributes: %i[street number zip_code])
   end
 end

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -13,7 +13,7 @@ class Owner < ApplicationRecord
   accepts_nested_attributes_for :document, :contact_infos, :address
 
   def contact_infos_attributes=(*attrs)
-    self.contact_infos.clear
+    contact_infos.clear
     super(*attrs)
   end
 end

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -11,4 +11,9 @@ class Owner < ApplicationRecord
 
   validates_presence_of :legal_name, :document, :contact_infos, :address
   accepts_nested_attributes_for :document, :contact_infos, :address
+
+  def contact_infos_attributes=(*attrs)
+    self.contact_infos.clear
+    super(*attrs)
+  end
 end

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -10,4 +10,5 @@ class Owner < ApplicationRecord
   has_many :recipient, dependent: :destroy
 
   validates_presence_of :legal_name
+  accepts_nested_attributes_for :contact_infos, :document, :address
 end

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -9,6 +9,6 @@ class Owner < ApplicationRecord
   has_one :address, dependent: :destroy
   has_many :recipient, dependent: :destroy
 
-  validates_presence_of :legal_name
-  accepts_nested_attributes_for :contact_infos, :document, :address
+  validates_presence_of :legal_name, :document, :contact_infos, :address
+  accepts_nested_attributes_for :document, :contact_infos, :address
 end

--- a/app/serializers/address_serializer.rb
+++ b/app/serializers/address_serializer.rb
@@ -1,0 +1,3 @@
+class AddressSerializer < ActiveModel::Serializer
+  attributes :street, :number, :zip_code
+end

--- a/app/serializers/address_serializer.rb
+++ b/app/serializers/address_serializer.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# Serializer method for Address model
 class AddressSerializer < ActiveModel::Serializer
   attributes :street, :number, :zip_code
 end

--- a/app/serializers/contact_info_serializer.rb
+++ b/app/serializers/contact_info_serializer.rb
@@ -1,0 +1,3 @@
+class ContactInfoSerializer < ActiveModel::Serializer
+  attributes :contact_type, :info
+end

--- a/app/serializers/contact_info_serializer.rb
+++ b/app/serializers/contact_info_serializer.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# Serializer class for ContactInfo model
 class ContactInfoSerializer < ActiveModel::Serializer
   attributes :contact_type, :info
 end

--- a/app/serializers/document_serializer.rb
+++ b/app/serializers/document_serializer.rb
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
+
+# Serializer Class for Document model
 class DocumentSerializer < ActiveModel::Serializer
   attributes :document_type, :number
-
 end

--- a/app/serializers/document_serializer.rb
+++ b/app/serializers/document_serializer.rb
@@ -1,0 +1,4 @@
+class DocumentSerializer < ActiveModel::Serializer
+  attributes :document_type, :number
+
+end

--- a/app/serializers/owner_serializer.rb
+++ b/app/serializers/owner_serializer.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# Serializer class for Owner model
 class OwnerSerializer < ActiveModel::Serializer
   attributes :id, :legal_name
 

--- a/app/serializers/owner_serializer.rb
+++ b/app/serializers/owner_serializer.rb
@@ -1,0 +1,7 @@
+class OwnerSerializer < ActiveModel::Serializer
+  attributes :id, :legal_name
+
+  has_one :document, serializer: DocumentSerializer
+  has_one :address, serializer: AddressSerializer
+  has_many :contact_infos, serializer: ContactInfoSerializer
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  resources :owners
 end

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -2,10 +2,9 @@
 
 FactoryBot.define do
   factory :address do
-    street { 'MyString' }
-    number { 1 }
-    zip_code { 'MyString' }
-    complement { 'MyString' }
-    owner { nil }
+    street { Faker::Address.street_name }
+    number { Faker::Address.building_number }
+    zip_code { Faker::Address.zip_code }
+    complement { [nil, "", Faker::Address.secondary_address].sample  }
   end
 end

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     street { Faker::Address.street_name }
     number { Faker::Address.building_number }
     zip_code { Faker::Address.zip_code }
-    complement { [nil, "", Faker::Address.secondary_address].sample  }
+    complement { [nil, '', Faker::Address.secondary_address].sample }
   end
 end

--- a/spec/factories/contact_infos.rb
+++ b/spec/factories/contact_infos.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :contact_info do
-    contact_type { %w(email, cel, land_number).sample }
+    contact_type { %w[email cel land_number].sample }
     info { 'MyString' }
   end
 end

--- a/spec/factories/contact_infos.rb
+++ b/spec/factories/contact_infos.rb
@@ -2,8 +2,7 @@
 
 FactoryBot.define do
   factory :contact_info do
-    document_type { '' }
+    contact_type { %w(email, cel, land_number).sample }
     info { 'MyString' }
-    owner { nil }
   end
 end

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :document do
     number { Faker::IDNumber.valid }
-    document_type { %w(ID, Passpot) }
+    document_type { %w(ID, Passpot, CPF, CNPJ).sample }
   end
 end

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :document do
     number { Faker::IDNumber.valid }
-    document_type { %w(ID, Passpot, CPF, CNPJ).sample }
+    document_type { %w[ID Passpot CPF CNPJ].sample }
   end
 end

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :document do
-    number { 'MyString' }
-    document_type { '' }
+    number { Faker::IDNumber.valid }
+    document_type { %w(ID, Passpot) }
   end
 end

--- a/spec/factories/owners.rb
+++ b/spec/factories/owners.rb
@@ -4,5 +4,8 @@ FactoryBot.define do
   factory :owner do
     legal_name { Faker::StarWars.character }
     metadata { 'MyString' }
+    document { FactoryBot.build :document }
+    contact_infos { [FactoryBot.build(:contact_info)] }
+    address { FactoryBot.build :address }
   end
 end

--- a/spec/models/owner_spec.rb
+++ b/spec/models/owner_spec.rb
@@ -9,4 +9,9 @@ RSpec.describe Owner, type: :model do
   it { should have_many(:recipient) }
 
   it { should validate_presence_of(:legal_name) }
+  it { should validate_presence_of(:document) }
+  it { should validate_presence_of(:contact_infos) }
+  it { should validate_presence_of(:address) }
+    
+  
 end

--- a/spec/models/owner_spec.rb
+++ b/spec/models/owner_spec.rb
@@ -12,6 +12,4 @@ RSpec.describe Owner, type: :model do
   it { should validate_presence_of(:document) }
   it { should validate_presence_of(:contact_infos) }
   it { should validate_presence_of(:address) }
-    
-  
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -28,6 +28,9 @@ require 'rspec/rails'
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
+# Add support Folder
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
@@ -69,6 +72,12 @@ RSpec.configure do |config|
       example.run
     end
   end
+
+  # Include RequestSpecHelper
+  config.include RequestSpecHelper, type: :request
+  config.include RSpec::Rails::RequestExampleGroup, type: :request
+
+  config.infer_spec_type_from_file_location!
 
 end
 

--- a/spec/requests/owners_spec.rb
+++ b/spec/requests/owners_spec.rb
@@ -190,5 +190,40 @@ RSpec.describe 'Owners API', type: :request do
       end
     end
 
+      context 'passing contact_infos attributes' do
+        let(:new_contact_infos) do
+              [
+                {contact_type: %w(email cell_phone land_number).sample, 
+                 info: Faker::Internet.email },
+                {contact_type: %w(email cell_phone land_number).sample, 
+                 info: Faker::Internet.email }
+              ]
+        end
+        let(:owner){ owners.last }
+        let(:owner_serializer) { OwnerSerializer.new(owner) }
+
+        context 'should' do
+          before { put "/owners/#{owner.id}", params: { contact_infos_attributes: new_contact_infos } }
+
+          it 'return 204 No Content' do
+            expect(response).to have_http_status(204)
+          end
+
+          it 'update the contact_infos values' do
+            get "/owners/#{owner.id}"
+            expect(json['contact_infos'].map{ |item| item.symbolize_keys } ).to eq(new_contact_infos)
+            expect(json['contact_infos'].map{ |item| item.symbolize_keys} ).not_to eq(owner_serializer.serializable_hash[:contact_infos])
+          end
+
+          it 'not update the other properties' do
+            get "/owners/#{owner.id}"
+            expect(json['legal_name']).to eq(owner.legal_name)
+            expect(json['address'].symbolize_keys  ).to eq(owner_serializer.serializable_hash[:address])
+            expect(json['document'].symbolize_keys  ).to eq(owner_serializer.serializable_hash[:document])
+          end
+
+        end
+
+      end
 
 end

--- a/spec/requests/owners_spec.rb
+++ b/spec/requests/owners_spec.rb
@@ -44,10 +44,9 @@ RSpec.describe 'Owners API', type: :request do
 
     describe 'DELETE /owners/:id' do
       let(:owner_id) { owners.last.id }
-      before {  delete "/owners/#{ owner_id}"}
+      before { delete "/owners/#{owner_id}" }
 
-      context "when owner is deleted" do
-
+      context 'when owner is deleted' do
         it 'return sucess and no content' do
           expect(response).to have_http_status(204)
         end
@@ -56,208 +55,250 @@ RSpec.describe 'Owners API', type: :request do
           get "/owners/#{owner_id}"
           expect(response).to have_http_status(404)
         end
-
       end
-
     end
   end
 
-    describe 'POST /owners' do
-      context 'when invalid params' do
-        
-        it 'miss all returns Bad Request(400)' do
-          post  '/owners', params: {}
-          expect(response).to have_http_status(400)
-        end
+  describe 'POST /owners' do
+    context 'when invalid params' do
+      it 'miss all returns Bad Request(400)' do
+        post '/owners', params: {}
+        expect(response).to have_http_status(400)
+      end
 
-        it 'miss legal_name only' do
-          post  '/owners', params: {contact_infos_attributes: [], 
-                                    document_attributes: { 
-                                          document_type: %w(CPF CNPJ).sample, 
-                                          number: Faker::Number.number(11) },
+      it 'miss legal_name only' do
+        post '/owners', params: { contact_infos_attributes: [],
+                                  document_attributes: {
+                                    document_type: %w[CPF CNPJ].sample,
+                                    number: Faker::Number.number(11)
+                                  },
                                   address_attributes: {
-                                              street: Faker::Address.street_name,
-                                              number: Faker::Address.building_number,
-                                              zip_code:  Faker::Address.zip_code,
-                                              complement: [nil, "", Faker::Address.secondary_address].sample  }
-          }
-          expect(response).to have_http_status(400)
-        end
-
-        it 'miss contact_infos_attributes' do
-          post '/owners', params: {legal_name: Faker::StarWars.character, 
-                                   document_attributes: { document_type: %w(CPF CNPJ).sample, number: Faker::Number.number(10)},
-                                    address_attributes: {
-                                              street: Faker::Address.street_name,
-                                              number: Faker::Address.building_number,
-                                              zip_code:  Faker::Address.zip_code,
-                                              complement: [nil, "", Faker::Address.secondary_address].sample  }
-          }
-          expect(response).to have_http_status(400)
-        end
-
-        it 'miss document' do
-          post '/owners', params: {legal_name: Faker::StarWars.character, 
-                                   contact_infos_attributes: [],
-            
-                                    address_attributes: {
-                                              street: Faker::Address.street_name,
-                                              number: Faker::Address.building_number,
-                                              zip_code:  Faker::Address.zip_code,
-                                              complement: [nil, "", Faker::Address.secondary_address].sample  }
-          }
-          expect(response).to have_http_status(400)
-        end
-        
-        it 'miss address_attributes_attribtues' do
-          post '/owners', params: {legal_name: Faker::StarWars.character,
-                                  contact_infos_attributes: [], document_attributes: { document_type: %w(CPF CNPJ).sample, number: Faker::Number.number(11)} } 
-          expect(response).to have_http_status(400)
-        end
-      end
-    
-      context  'when valid params' do
-        before do
-          post '/owners', params:  {legal_name: Faker::StarWars.character, 
-                                    document_attributes: { document_type: %w(CPF CNPJ).sample, 
-                                                           number: Faker::Number.number(11)},
-                                    contact_infos_attributes:  [{contact_type: %w(email cell_phone land_number).sample, 
-                                                      info: Faker::Internet.email }],
-                                    address_attributes: {
-                                              street: Faker::Address.street_name,
-                                              number: Faker::Address.building_number,
-                                              zip_code:  Faker::Address.zip_code,
-                                              complement: [nil, "", Faker::Address.secondary_address].sample  }
-
-                                    }
-        end
-
-        it 'returns 201 OK' do
-          expect(response).to have_http_status(201)
-        end
-
-
+                                    street: Faker::Address.street_name,
+                                    number: Faker::Address.building_number,
+                                    zip_code:  Faker::Address.zip_code,
+                                    complement: [nil, '',
+                                                 Faker::Address.secondary_address].sample
+                                  } }
+        expect(response).to have_http_status(400)
       end
 
-    end
-
-    describe "PUT /owners/:id" do
-      let(:owner) {owners.last}
-
-      context 'passing legal_name attribute' do
-        let(:new_legal_name) {  'new_legal_name' }
-        before { put "/owners/#{owner.id}", params: {legal_name: new_legal_name }}
-        
-        it  'returns 204 No Content' do
-          expect(response).to have_http_status(204)
-        end
-        
-        it 'updates the resource' do
-          get "/owners/#{owner.id}"
-          expect(json['legal_name']).to eq(new_legal_name)
-
-        end
-
+      it 'miss contact_infos_attributes' do
+        post '/owners', params: { legal_name: Faker::StarWars.character,
+                                  document_attributes: { document_type: %w[CPF CNPJ].sample,
+                                                         number: Faker::Number.number(10) },
+                                  address_attributes: {
+                                    street: Faker::Address.street_name,
+                                    number: Faker::Address.building_number,
+                                    zip_code:  Faker::Address.zip_code,
+                                    complement: [nil, '', Faker::Address.secondary_address].sample
+                                  } }
+        expect(response).to have_http_status(400)
       end
 
-      context 'passing documment attributes' do
-        let(:new_document) { {document_type: %w(CPF CNPJ).sample, number: Faker::Number.number(11)} }
-        let(:owner){ owners.last }
-        before{ put "/owners/#{owner.id}", params: { document_attributes: new_document} }
-        let(:owner_serializer) { OwnerSerializer.new(owner) }
+      it 'miss document' do
+        post '/owners', params: { legal_name: Faker::StarWars.character,
+                                  contact_infos_attributes: [],
 
-        it 'returns 204 No Content' do
-          expect(response).to have_http_status(204)
-        end
+                                  address_attributes: {
+                                    street: Faker::Address.street_name,
+                                    number: Faker::Address.building_number,
+                                    zip_code:  Faker::Address.zip_code,
+                                    complement: [nil, '', Faker::Address.secondary_address].sample
+                                  } }
+        expect(response).to have_http_status(400)
+      end
 
-        it 'updates the document in resource' do
-          get "/owners/#{owner.id}"
-          expect(json['document']['document_type']).to eq(new_document[:document_type])
-          expect(json['document']['number']).to eq(new_document[:number])
-
-          # We are not testing the document_type update because it is a random choise in a list, then 
-          # Testing it could cause tests failures.
-          expect(json['document']['number']).not_to eq(owner_serializer.serializable_hash[:address][:number])
-        end
-
-        it 'doesn\'t other properties' do
-          get "/owners/#{owner.id}"
-          expect(json['legal_name']).to eq(owner.legal_name)
-          expect(json['contact_infos'].map{ |item|  item.symbolize_keys } ).to eq(owner_serializer.serializable_hash[:contact_infos])
-          expect(json['address'].symbolize_keys  ).to eq(owner_serializer.serializable_hash[:address])
-          
-        end
+      it 'miss address_attributes_attribtues' do
+        post '/owners', params: { legal_name: Faker::StarWars.character,
+                                  contact_infos_attributes: [],
+                                  document_attributes: { document_type: %w[CPF CNPJ].sample,
+                                                         number: Faker::Number.number(11) } }
+        expect(response).to have_http_status(400)
       end
     end
 
-      context 'passing contact_infos attributes' do
-        let(:new_contact_infos) do
-              [
-                {contact_type: %w(email cell_phone land_number).sample, 
-                 info: Faker::Internet.email },
-                {contact_type: %w(email cell_phone land_number).sample, 
-                 info: Faker::Internet.email }
-              ]
-        end
-        let(:owner){ owners.last }
-        let(:owner_serializer) { OwnerSerializer.new(owner) }
-
-        context 'should' do
-          before { put "/owners/#{owner.id}", params: { contact_infos_attributes: new_contact_infos } }
-
-          it 'return 204 No Content' do
-            expect(response).to have_http_status(204)
-          end
-
-          it 'update the contact_infos values' do
-            get "/owners/#{owner.id}"
-            expect(json['contact_infos'].map{ |item| item.symbolize_keys } ).to eq(new_contact_infos)
-            expect(json['contact_infos'].map{ |item| item.symbolize_keys} ).not_to eq(owner_serializer.serializable_hash[:contact_infos])
-          end
-
-          it 'not update the other properties' do
-            get "/owners/#{owner.id}"
-            expect(json['legal_name']).to eq(owner.legal_name)
-            expect(json['address'].symbolize_keys  ).to eq(owner_serializer.serializable_hash[:address])
-            expect(json['document'].symbolize_keys  ).to eq(owner_serializer.serializable_hash[:document])
-          end
-
-        end
-
+    context  'when valid params' do
+      before do
+                post '/owners', 
+                params:  { legal_name: Faker::StarWars.character,
+                   document_attributes: { document_type: %w[CPF CNPJ].sample,
+                                          number: Faker::Number.number(11) },
+                                          contact_infos_attributes: [
+                                                                      { contact_type: %w[email
+                                                                           cell_phone
+                                                                           land_number].sample,
+                                                                      info: Faker::Internet.email }
+                                                                    ],
+                                          address_attributes: {
+                                            street: Faker::Address.street_name,
+                                            number: Faker::Address.building_number,
+                                            zip_code:  Faker::Address.zip_code,
+                                            complement: [nil, '',
+                                                         Faker::Address.secondary_address].sample } }
       end
 
-      context 'passing address attributes' do 
-        let(:new_address) do
-          {
-            street: Faker::Address.street_name,
-            number: Faker::Address.building_number,
-            zip_code:  Faker::Address.zip_code,
-            complement: [nil, "", Faker::Address.secondary_address].sample  
-          }
-        end
-        let(:owner){ owners.last }
-        let(:owner_serializer) { OwnerSerializer.new(owner) }
-
-        context 'should' do
-          before{ put "/owners/#{owner.id}", params: {adress_attributes: new_address } }
-
-          it 'return 204 No Content' do
-            expect(response).to have_http_status(204)
-          end
-
-          it 'update address values' do
-            get "/owners/#{owner.id}"
-            expect(json["address"].symbolize_keys).to eq(owner_serializer.serializable_hash[:address])
-          end
-        
-          it 'not update other values' do
-            get "/owners/#{owner.id}"
-            expect(json['legal_name']).to eq(owner.legal_name)
-            expect(json['document'].symbolize_keys  ).to eq(owner_serializer.serializable_hash[:document])
-            expect(json['contact_infos'].map{ |item|  item.symbolize_keys } ).to eq(owner_serializer.serializable_hash[:contact_infos])
-          end
-
-        end
-  
+      it 'returns 201 OK' do
+        expect(response).to have_http_status(201)
       end
+    end
+  end
+
+  describe 'PUT /owners/:id' do
+    let(:owner) { owners.last }
+
+    context 'passing legal_name attribute' do
+      let(:new_legal_name) { 'new_legal_name' }
+      before { put "/owners/#{owner.id}", params: { legal_name: new_legal_name } }
+
+      it 'returns 204 No Content' do
+        expect(response).to have_http_status(204)
+      end
+
+      it 'updates the resource' do
+        get "/owners/#{owner.id}"
+        expect(json['legal_name']).to eq(new_legal_name)
+      end
+    end
+
+    context 'passing documment attributes' do
+      let(:new_document) do
+        { document_type: %w[CPF CNPJ].sample,
+          number: Faker::Number.number(11) }
+      end
+
+      let(:owner) { owners.last }
+      before { put "/owners/#{owner.id}", params: { document_attributes: new_document } }
+      let(:owner_serializer) { OwnerSerializer.new(owner) }
+
+      it 'returns 204 No Content' do
+        expect(response).to have_http_status(204)
+      end
+
+      it 'updates the document in resource' do
+        get "/owners/#{owner.id}"
+        expect(json['document']['document_type']).to eq(new_document[:document_type])
+        expect(json['document']['number']).to eq(new_document[:number])
+
+        # We are not testing the document_type update because it is a random choise in a list,
+        # then testing it could cause tests failures.
+        expect(
+          json['document']['number']
+        ).not_to eq(
+          owner_serializer.serializable_hash[:address][:number]
+        )
+      end
+
+      it 'doesn\'t other properties' do
+        get "/owners/#{owner.id}"
+        expect(json['legal_name']).to eq(owner.legal_name)
+
+        expect(
+          json['contact_infos'].map(&:symbolize_keys)
+        ).to eq(
+          owner_serializer.serializable_hash[:contact_infos]
+        )
+
+        expect(
+          json['address'].symbolize_keys
+        ).to eq(
+          owner_serializer.serializable_hash[:address]
+        )
+      end
+    end
+  end
+
+  context 'passing contact_infos attributes' do
+    let(:new_contact_infos) do
+      [
+        { contact_type: %w[email cell_phone land_number].sample,
+          info: Faker::Internet.email },
+        { contact_type: %w[email cell_phone land_number].sample,
+          info: Faker::Internet.email }
+      ]
+    end
+    let(:owner) { owners.last }
+    let(:owner_serializer) { OwnerSerializer.new(owner) }
+
+    context 'should' do
+      before do
+        put "/owners/#{owner.id}",
+        params: { contact_infos_attributes: new_contact_infos }
+      end
+
+      it 'return 204 No Content' do
+        expect(response).to have_http_status(204)
+      end
+
+      it 'update the contact_infos values' do
+        get "/owners/#{owner.id}"
+        expect(json['contact_infos'].map(&:symbolize_keys)).to eq(new_contact_infos)
+        expect(
+          json['contact_infos'].map(&:symbolize_keys)
+        ).not_to eq(
+          owner_serializer.serializable_hash[:contact_infos]
+        )
+      end
+
+      it 'not update the other properties' do
+        get "/owners/#{owner.id}"
+        expect(json['legal_name']).to eq(owner.legal_name)
+        expect(
+          json['address'].symbolize_keys
+        ).to eq(
+          owner_serializer.serializable_hash[:address]
+        )
+
+        expect(
+          json['document'].symbolize_keys
+        ).to eq(
+          owner_serializer.serializable_hash[:document]
+        )
+      end
+    end
+  end
+
+  context 'passing address attributes' do
+    let(:new_address) do
+      {
+        street: Faker::Address.street_name,
+        number: Faker::Address.building_number,
+        zip_code:  Faker::Address.zip_code,
+        complement: [nil, '', Faker::Address.secondary_address].sample
+      }
+    end
+    let(:owner) { owners.last }
+    let(:owner_serializer) { OwnerSerializer.new(owner) }
+
+    context 'should' do
+      before { put "/owners/#{owner.id}", params: { adress_attributes: new_address } }
+
+      it 'return 204 No Content' do
+        expect(response).to have_http_status(204)
+      end
+
+      it 'update address values' do
+        get "/owners/#{owner.id}"
+        expect(
+          json['address'].symbolize_keys
+        ).to eq(
+          owner_serializer.serializable_hash[:address]
+        )
+      end
+
+      it 'not update other values' do
+        get "/owners/#{owner.id}"
+        expect(json['legal_name']).to eq(owner.legal_name)
+        expect(
+          json['document'].symbolize_keys
+        ).to eq(
+          owner_serializer.serializable_hash[:document]
+        )
+        expect(
+          json['contact_infos'].map(&:symbolize_keys)
+        ).to eq(
+          owner_serializer.serializable_hash[:contact_infos]
+        )
+      end
+    end
+  end
 end

--- a/spec/requests/owners_spec.rb
+++ b/spec/requests/owners_spec.rb
@@ -61,4 +61,83 @@ RSpec.describe 'Owners API', type: :request do
 
     end
   end
+
+    describe 'POST /owners' do
+      context 'when invalid params' do
+        
+        it 'miss all returns Bad Request(400)' do
+          post  '/owners', params: {}
+          expect(response).to have_http_status(400)
+        end
+
+        it 'miss legal_name only' do
+          post  '/owners', params: {contact_infos_attributes: [], 
+                                    document_attributes: { 
+                                          document_type: %w(CPF CNPJ).sample, 
+                                          number: 12345},
+                                  address_attributes: {
+                                              street: Faker::Address.street_name,
+                                              number: Faker::Address.building_number,
+                                              zip_code:  Faker::Address.zip_code,
+                                              complement: [nil, "", Faker::Address.secondary_address].sample  }
+          }
+          expect(response).to have_http_status(400)
+        end
+
+        it 'miss contact_infos_attributes' do
+          post '/owners', params: {legal_name: Faker::StarWars.character, 
+                                   document_attributes: { document_type: %w(CPF CNPJ).sample, number: 1234},
+                                    address_attributes: {
+                                              street: Faker::Address.street_name,
+                                              number: Faker::Address.building_number,
+                                              zip_code:  Faker::Address.zip_code,
+                                              complement: [nil, "", Faker::Address.secondary_address].sample  }
+          }
+          expect(response).to have_http_status(400)
+        end
+
+        it 'miss document' do
+          post '/owners', params: {legal_name: Faker::StarWars.character, 
+                                   contact_infos_attributes: [],
+            
+                                    address_attributes: {
+                                              street: Faker::Address.street_name,
+                                              number: Faker::Address.building_number,
+                                              zip_code:  Faker::Address.zip_code,
+                                              complement: [nil, "", Faker::Address.secondary_address].sample  }
+          }
+          expect(response).to have_http_status(400)
+        end
+        
+        it 'miss address_attributes_attribtues' do
+          post '/owners', params: {legal_name: Faker::StarWars.character,
+                                  contact_infos_attributes: [], document_attributes: { document_type: %w(CPF CNPJ).sample, number: 12345} } 
+          expect(response).to have_http_status(400)
+        end
+      end
+    
+      context  'when valid params' do
+        before do
+          post '/owners', params:  {legal_name: Faker::StarWars.character, 
+                                    document_attributes: { document_type: %w(CPF CNPJ).sample, 
+                                                           number: 12345},
+                                    contact_infos_attributes:  [{contact_type: %w(email cell_phone land_number).sample, 
+                                                      info: Faker::Internet.email }],
+                                    address_attributes: {
+                                              street: Faker::Address.street_name,
+                                              number: Faker::Address.building_number,
+                                              zip_code:  Faker::Address.zip_code,
+                                              complement: [nil, "", Faker::Address.secondary_address].sample  }
+
+                                    }
+        end
+
+        it 'returns 200 OK' do
+          expect(response).to have_http_status(201)
+        end
+
+
+      end
+
+    end
 end

--- a/spec/requests/owners_spec.rb
+++ b/spec/requests/owners_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'net/http'
+
+RSpec.describe 'Owners API', type: :request do
+  let!(:owners) { create_list(:owner, 10) }
+
+  describe 'GET /owners' do
+    before { get '/owners' }
+
+    it 'returns owners' do
+      expect(json).not_to be_empty
+      expect(json.size).to eq(10)
+    end
+
+    it 'returns HTTP OK' do
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'GET /owners/:id' do
+    let(:owner_id) { owners.first.id }
+    before { get "/owners/#{owner_id}" }
+
+    context 'when the owner record exists' do
+      it 'returns the owner' do
+        expect(json).not_to be_empty
+        expect(json['id']).to eq(owner_id)
+      end
+
+      it 'returns HTTP OK' do
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'when the owner record does not exist' do
+      let(:owner_id) { 100 }
+
+      it 'returns HTTP NOT FOUND' do
+        expect(response).to have_http_status(404)
+      end
+    end
+
+    describe 'DELETE /owners/:id' do
+      let(:owner_id) { owners.last.id }
+      before {  delete "/owners/#{ owner_id}"}
+
+      context "when owner is deleted" do
+
+        it 'return sucess and no content' do
+          expect(response).to have_http_status(204)
+        end
+
+        it 'doesnt exist anymore' do
+          get "/owners/#{owner_id}"
+          expect(response).to have_http_status(404)
+        end
+
+      end
+
+    end
+  end
+end

--- a/spec/requests/owners_spec.rb
+++ b/spec/requests/owners_spec.rb
@@ -226,4 +226,38 @@ RSpec.describe 'Owners API', type: :request do
 
       end
 
+      context 'passing address attributes' do 
+        let(:new_address) do
+          {
+            street: Faker::Address.street_name,
+            number: Faker::Address.building_number,
+            zip_code:  Faker::Address.zip_code,
+            complement: [nil, "", Faker::Address.secondary_address].sample  
+          }
+        end
+        let(:owner){ owners.last }
+        let(:owner_serializer) { OwnerSerializer.new(owner) }
+
+        context 'should' do
+          before{ put "/owners/#{owner.id}", params: {adress_attributes: new_address } }
+
+          it 'return 204 No Content' do
+            expect(response).to have_http_status(204)
+          end
+
+          it 'update address values' do
+            get "/owners/#{owner.id}"
+            expect(json["address"].symbolize_keys).to eq(owner_serializer.serializable_hash[:address])
+          end
+        
+          it 'not update other values' do
+            get "/owners/#{owner.id}"
+            expect(json['legal_name']).to eq(owner.legal_name)
+            expect(json['document'].symbolize_keys  ).to eq(owner_serializer.serializable_hash[:document])
+            expect(json['contact_infos'].map{ |item|  item.symbolize_keys } ).to eq(owner_serializer.serializable_hash[:contact_infos])
+          end
+
+        end
+  
+      end
 end

--- a/spec/requests/owners_spec.rb
+++ b/spec/requests/owners_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'Owners API', type: :request do
                                     }
         end
 
-        it 'returns 200 OK' do
+        it 'returns 201 OK' do
           expect(response).to have_http_status(201)
         end
 
@@ -140,4 +140,28 @@ RSpec.describe 'Owners API', type: :request do
       end
 
     end
+
+    describe "PUT /owners" do
+      let(:owner) {owners.last}
+
+      context "Update legal_name" do
+        let(:new_legal_name) {  'new_legal_name' }
+        before { put "/owners/#{owner.id}", params: {legal_name: new_legal_name }}
+        
+        it  'returns 204 No Content' do
+          expect(response).to have_http_status(204)
+        end
+        
+        it 'updates the resource' do
+          get "/owners/#{owner.id}"
+          expect(json['legal_name']).to eq(new_legal_name)
+
+        end
+
+      end
+      
+
+    end
+
+
 end

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module RequestSpecHelper
+  # Parse JSON response to Ruby hash
+  def json
+    JSON.parse(response.body)
+  end
+end


### PR DESCRIPTION
This pull request intends to add the `Owner` REST API . It is able to

- List Owners; `GET /owners` 
- Access a specific owner by ID; `GET /owners/:id`
- Delete a specific owner by ID; `DELETE /owners/:id`
- Create an Owner by passing a JSON data; `POST /owners`
- Update an Owner by passing a JSON data; `PUT /owners/:id`

TODO LIST

- [x] Create action
- [x] Delete action
- [x] List action
- [x] Update action
- [x] Access unique action
- [x] Test List action
- [x] Test Access unique action
- [x] Test Delete action
- [x] Test creation(POST) action(considering the nested params)
- [x] Test update action(considering the ntested params)